### PR TITLE
Retain input volume to better simulate mute toggle

### DIFF
--- a/togglemic.applescript
+++ b/togglemic.applescript
@@ -1,11 +1,15 @@
 -- technique from http://www.alfredforum.com/topic/2486-mute-mic/
 -- code from http://superuser.com/a/397770/40768
---     54 is where my mic is set. Yours may be different
+
+-- If script is recompiled, e.g. because it gets modified, then the property
+-- will be reset to the default value of 100
+property previousInputVolume : 100
 
 set inputVolume to input volume of (get volume settings)
 if inputVolume = 0 then
-    set inputVolume to 54
+    set inputVolume to previousInputVolume
 else
+    copy inputVolume to previousInputVolume
     set inputVolume to 0
 end if
 set volume input volume inputVolume


### PR DESCRIPTION
The output volume remains unchanged when muted and subsequently
un-muted.  Attempt to simulate this behavior by persisting the input
volume when mic-mute is toggled on and then using this persisted value
when toggled off.

If the user uses another method for muting the mic, e.g. navigating to
Sound under System Properties, then the last value of the input volume
will not be saved (but a prior value will still be in the property).
Note: only one value is saved, not a value for each input device.